### PR TITLE
Add default renovate config for miscord-dev

### DIFF
--- a/default.json
+++ b/default.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["config:base"]
+}

--- a/default.json
+++ b/default.json
@@ -1,3 +1,3 @@
 {
-  "extends": ["config:base"]
+  "extends": ["config:base", ":disableDependencyDashboard"]
 }

--- a/default.json
+++ b/default.json
@@ -1,4 +1,7 @@
 {
   "extends": ["config:base"],
-  "dependencyDashboard": false
+  "dependencyDashboard": false,
+  "major": {
+    "enabled": false
+  }
 }

--- a/default.json
+++ b/default.json
@@ -3,5 +3,11 @@
   "dependencyDashboard": false,
   "major": {
     "enabled": false
-  }
+  },
+  "packageRules": [
+    {
+      "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
+      "automerge": true
+    }
+  ]
 }

--- a/default.json
+++ b/default.json
@@ -6,7 +6,7 @@
   },
   "packageRules": [
     {
-      "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
+      "matchUpdateTypes": ["patch"],
       "automerge": true
     }
   ]

--- a/default.json
+++ b/default.json
@@ -1,3 +1,4 @@
 {
-  "extends": ["config:base", ":disableDependencyDashboard"]
+  "extends": ["config:base"],
+  "dependencyDashboard": false
 }


### PR DESCRIPTION
- Disable suggestions for major version update
- Disable annoying dependency dashboard
- Enable auto-merge only for patch version updates (which could be more conservative)